### PR TITLE
Adding verification of node and query

### DIFF
--- a/components/atoms/VerifyNode.js
+++ b/components/atoms/VerifyNode.js
@@ -160,7 +160,6 @@ export const VerifyNode = ({ idx, copyCodeToClipboard }) => {
   };
 
   const signSignature = async (hoprAddress, hoprSignature, ethAddress) => {
-    console.log("INPUT", hoprAddress, hoprSignature, ethAddress)
     const message = getWeb3SignatureVerifyContents(hoprAddress, hoprSignature, ethAddress);
     const signature = await library
       .getSigner()
@@ -175,8 +174,7 @@ export const VerifyNode = ({ idx, copyCodeToClipboard }) => {
       signature,
       message
     );
-    console.log("SERVER RESPONSE", response);
-    return response;
+    return response.message;
   };
 
   const signRequest = async (hoprAddress, ethAddress) => {
@@ -361,13 +359,16 @@ export const VerifyNode = ({ idx, copyCodeToClipboard }) => {
           />
         </div>
         <button
-          disabled={!signatureValue}
-          onClick={() => {
-            signSignature(inputValue, signatureValue, account);
+          disabled={!signatureValue || isLoading}
+          onClick={async () => {
+            setLoading(true);
+            const message = await signSignature(inputValue, signatureValue, account);
+            setLoading(false);
+            alert(message);
           }}
           style={{ backgroundColor: "rgba(248, 114, 54, 0.5)" }}
         >
-          Verify node for rewards.
+          { isLoading ?  'Adding your node' : 'Verify node for rewards' }
         </button>
       </div>
     </div>

--- a/components/atoms/VerifyNode.js
+++ b/components/atoms/VerifyNode.js
@@ -159,7 +159,8 @@ export const VerifyNode = ({ idx, copyCodeToClipboard }) => {
     setProfile(profile);
   };
 
-  const signSignature = async (hoprSignature = "hello world", ethAddress) => {
+  const signSignature = async (hoprAddress, hoprSignature, ethAddress) => {
+    console.log("INPUT", hoprAddress, hoprSignature, ethAddress)
     const message = getWeb3SignatureVerifyContents(hoprAddress, hoprSignature, ethAddress);
     const signature = await library
       .getSigner()
@@ -362,7 +363,7 @@ export const VerifyNode = ({ idx, copyCodeToClipboard }) => {
         <button
           disabled={!signatureValue}
           onClick={() => {
-            signSignature(signatureValue, account);
+            signSignature(inputValue, signatureValue, account);
           }}
           style={{ backgroundColor: "rgba(248, 114, 54, 0.5)" }}
         >

--- a/components/atoms/VerifyNode.js
+++ b/components/atoms/VerifyNode.js
@@ -19,7 +19,8 @@ const getWeb3SignatureFaucetContents = (hoprAddress, ethAddress) => ({
   ethAddress,
 });
 
-const getWeb3SignatureVerifyContents = (hoprSignature, ethAddress) => ({
+const getWeb3SignatureVerifyContents = (hoprAddress, hoprSignature, ethAddress) => ({
+  hoprAddress,
   hoprSignature,
   ethAddress,
 });
@@ -159,7 +160,7 @@ export const VerifyNode = ({ idx, copyCodeToClipboard }) => {
   };
 
   const signSignature = async (hoprSignature = "hello world", ethAddress) => {
-    const message = getWeb3SignatureVerifyContents(hoprSignature, ethAddress);
+    const message = getWeb3SignatureVerifyContents(hoprAddress, hoprSignature, ethAddress);
     const signature = await library
       .getSigner()
       ._signTypedData(
@@ -322,16 +323,30 @@ export const VerifyNode = ({ idx, copyCodeToClipboard }) => {
         <small>
           By verifying your node, you are elegible to NFT rewards based on the
           on-chain actions your node(s) execute(s). You can only verify nodes
-          you control. Copy your Ethereum address and go to the admin interface
-          of your HOPR node. Using the command “sign”, sign your copied address
-          and paste the result here. e.g. “sign
-          0x2402da10A6172ED018AEEa22CA60EDe1F766655C”
+          you control. First, add your HOPR node address in the following input
+          value field.
+        </small>
+        <div display="block" style={{ marginTop: "10px" }}>
+          <input
+            type="text"
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder="16Uiu2HA..."
+            style={{ width: "98%", padding: "5px" }}
+          />
+        </div>
+        <br />
+        <small>
+          Now, copy your Ethereum address (the one you want your NFT rewards to
+          go to and you can use for signing, usually your MetaMask one) and go
+          to the admin interface of your HOPR node. Using the command “sign”,
+          sign your copied address and paste the result here. e.g. “sign
+          {' '}{account}”
         </small>
         <br />
         <br />
         <small>
           Copy and paste the contents of the sign function in the following text
-          field and click on “Verify your HOPR node in IDX”. If valid, your node
+          field and click on “Verify node for rewards”. If valid, your node
           will then be shown as verified in our network with your Ethereum
           address.
         </small>

--- a/constants/ceramic.js
+++ b/constants/ceramic.js
@@ -4,3 +4,4 @@ export const CERAMIC_IDX_ALIASES = {
   alias1: "basicProfile",
 };
 export const CERAMIC_IDX_HOPR_NAMESPACE = 'hopr-wildhorn'
+export const CERAMIC_TILE_ID = 'kjzl6cwe1jw1468n6gtygg5kdg0j69treni29fruvwxvatff9ebb4p4q995fv4i'

--- a/constants/hopr.js
+++ b/constants/hopr.js
@@ -20,6 +20,7 @@ export const HOPR_WEB3_SIGNATURE_TYPES = {
 
 export const HOPR_WEB3_SIGNATURE_FOR_NODE_TYPES = {
   Node: [
+    { name: "hoprAddress", type: "string" },
     { name: "hoprSignature", type: "string" },
     { name: "ethAddress", type: "address" },
   ],

--- a/constants/hopr.js
+++ b/constants/hopr.js
@@ -17,3 +17,10 @@ export const HOPR_WEB3_SIGNATURE_TYPES = {
     { name: "ethAddress", type: "address" },
   ],
 };
+
+export const HOPR_WEB3_SIGNATURE_FOR_NODE_TYPES = {
+  Node: [
+    { name: "hoprSignature", type: "string" },
+    { name: "ethAddress", type: "address" },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@3id/connect": "^0.1.6",
     "@ceramicnetwork/3id-did-resolver": "^1.3.1",
-    "@ceramicnetwork/http-client": "^1.1.1",
+    "@ceramicnetwork/http-client": "^1.2.0",
+    "@ceramicnetwork/stream-tile": "^1.2.0",
     "@ceramicstudio/idx": "^0.12.1",
     "@hoprnet/hopr-utils": "1.76.0-next.18",
     "@urql/core": "^2.2.0",
@@ -22,6 +23,8 @@
     "ethers": "^5.4.4",
     "graphql": "^15.5.1",
     "isomorphic-fetch": "3.0.0",
+    "key-did-provider-ed25519": "^1.1.0",
+    "key-did-resolver": "^1.4.0",
     "multiaddr": "^10.0.0",
     "next": "9.5.5",
     "node-sass": "4.14.1",

--- a/pages/api/sign/get/all.js
+++ b/pages/api/sign/get/all.js
@@ -3,7 +3,10 @@ import KeyResolver from "key-did-resolver";
 import { DID } from "dids";
 import CeramicClient from "@ceramicnetwork/http-client";
 import { TileDocument } from "@ceramicnetwork/stream-tile";
-import { CERAMIC_API_URL } from "../../../../constants/ceramic";
+import {
+  CERAMIC_API_URL,
+  CERAMIC_TILE_ID,
+} from "../../../../constants/ceramic";
 
 import { utils } from "ethers";
 
@@ -13,19 +16,17 @@ const secretKey = Uint8Array.from(
 const provider = new Ed25519Provider(secretKey);
 const did = new DID({ provider, resolver: KeyResolver.getResolver() });
 const client = new CeramicClient(CERAMIC_API_URL);
-let tile = null;
+const tileId = CERAMIC_TILE_ID;
 
 export default async (req, res) => {
-  if (!tile) {
-    await did.authenticate();
-    client.setDID(did);
-    tile = await TileDocument.create(client, {});
-  }
+  await did.authenticate();
+  client.setDID(did);
 
-  const records = await TileDocument.load(client, tile.id);
+  const records = await TileDocument.load(client, tileId);
 
   return res.status(200).json({
     status: "ok",
+    tileId,
     records: records.content,
   });
 };

--- a/pages/api/sign/get/all.js
+++ b/pages/api/sign/get/all.js
@@ -1,0 +1,31 @@
+import { Ed25519Provider } from "key-did-provider-ed25519";
+import KeyResolver from "key-did-resolver";
+import { DID } from "dids";
+import CeramicClient from "@ceramicnetwork/http-client";
+import { TileDocument } from "@ceramicnetwork/stream-tile";
+import { CERAMIC_API_URL } from "../../../../constants/ceramic";
+
+import { utils } from "ethers";
+
+const secretKey = Uint8Array.from(
+  utils.arrayify(`0x${process.env.HOPR_DASHBOARD_API_PRIVATE_KEY}`)
+);
+const provider = new Ed25519Provider(secretKey);
+const did = new DID({ provider, resolver: KeyResolver.getResolver() });
+const client = new CeramicClient(CERAMIC_API_URL);
+let tile = null;
+
+export default async (req, res) => {
+  if (!tile) {
+    await did.authenticate();
+    client.setDID(did);
+    tile = await TileDocument.create(client, {});
+  }
+
+  const records = await TileDocument.load(client, tile.id);
+
+  return res.status(200).json({
+    status: "ok",
+    records: records.content,
+  });
+};

--- a/pages/api/sign/verify/[address].js
+++ b/pages/api/sign/verify/[address].js
@@ -1,21 +1,19 @@
-import { Ed25519Provider } from 'key-did-provider-ed25519'
-import KeyResolver from 'key-did-resolver'
-import { DID } from 'dids'
-import CeramicClient from '@ceramicnetwork/http-client'
-import { TileDocument } from '@ceramicnetwork/stream-tile'
+import { Ed25519Provider } from "key-did-provider-ed25519";
+import KeyResolver from "key-did-resolver";
+import { DID } from "dids";
+import CeramicClient from "@ceramicnetwork/http-client";
+import { TileDocument } from "@ceramicnetwork/stream-tile";
 import {
   HOPR_WEB3_SIGNATURE_DOMAIN,
   HOPR_WEB3_SIGNATURE_FOR_NODE_TYPES,
-  TOKEN_ADDRESS_POLYGON,
 } from "../../../../constants/hopr";
 import {
-  CERAMIC_API_URL
+  CERAMIC_API_URL,
+  CERAMIC_TILE_ID,
 } from "../../../../constants/ceramic";
 
 import { verifySignatureFromPeerId } from "@hoprnet/hopr-utils";
-import { formatEther } from "@ethersproject/units";
-import HOPR_TOKEN_ABI from "../../../../constants/HoprTokenABI";
-import { providers, utils, Wallet, Contract } from "ethers";
+import { utils} from "ethers";
 
 // NB: HOPR Node sign messages using the prefix to avoid having
 // the nodes sign any generic data which could be used maliciously
@@ -24,11 +22,13 @@ import { providers, utils, Wallet, Contract } from "ethers";
 // see https://github.com/hoprnet/hoprnet/blob/master/packages/core/src/index.ts#L865-L870
 const HOPR_PREFIX = "HOPR Signed Message: ";
 
-const secretKey = Uint8Array.from(utils.arrayify(`0x${process.env.HOPR_DASHBOARD_API_PRIVATE_KEY}`))
-const provider = new Ed25519Provider(secretKey)
-const did = new DID({ provider, resolver: KeyResolver.getResolver() })
-const client = new CeramicClient(CERAMIC_API_URL)
-let tile = null
+const secretKey = Uint8Array.from(
+  utils.arrayify(`0x${process.env.HOPR_DASHBOARD_API_PRIVATE_KEY}`)
+);
+const provider = new Ed25519Provider(secretKey);
+const did = new DID({ provider, resolver: KeyResolver.getResolver() });
+const client = new CeramicClient(CERAMIC_API_URL);
+const tileId = CERAMIC_TILE_ID;
 
 export default async (req, res) => {
   const { address } = req.query;
@@ -54,23 +54,21 @@ export default async (req, res) => {
     );
 
     if (isAddressOwnerOfNode) {
-      // @TODO: Move from API endpoint as this gets called everytime.
-      if (!tile) {
-        await did.authenticate()
-        client.setDID(did)
-        tile = await TileDocument.create(client, {})
-      }
 
-      const records = await TileDocument.load(client, tile.id)
-      const mutatedRecords = Object.assign({}, records.content, { [hoprAddress]: ethAddress })
-      await tile.update(mutatedRecords)
+      await did.authenticate();
+      client.setDID(did);
+
+      const docs = await TileDocument.load(client, tileId);
+      const mutatedDoc = Object.assign({}, docs.content, {
+        [hoprAddress]: ethAddress,
+      });
+      await docs.update(mutatedDoc);
 
       return res.status(200).json({
         status: "ok",
-        tile: tile.id.toString(),
+        tile: docs.id.toString(),
         message: `Your node was recorded into the Ceramic network.`,
       });
-
     } else {
       return res.status(200).json({
         status: "invalid",

--- a/pages/api/sign/verify/[address].js
+++ b/pages/api/sign/verify/[address].js
@@ -1,8 +1,17 @@
+import { Ed25519Provider } from 'key-did-provider-ed25519'
+import KeyResolver from 'key-did-resolver'
+import { DID } from 'dids'
+import CeramicClient from '@ceramicnetwork/http-client'
+import { TileDocument } from '@ceramicnetwork/stream-tile'
 import {
   HOPR_WEB3_SIGNATURE_DOMAIN,
   HOPR_WEB3_SIGNATURE_FOR_NODE_TYPES,
   TOKEN_ADDRESS_POLYGON,
 } from "../../../../constants/hopr";
+import {
+  CERAMIC_API_URL
+} from "../../../../constants/ceramic";
+
 import { verifySignatureFromPeerId } from "@hoprnet/hopr-utils";
 import { formatEther } from "@ethersproject/units";
 import HOPR_TOKEN_ABI from "../../../../constants/HoprTokenABI";
@@ -14,6 +23,12 @@ import { providers, utils, Wallet, Contract } from "ethers";
 // to get a valid signature.
 // see https://github.com/hoprnet/hoprnet/blob/master/packages/core/src/index.ts#L865-L870
 const HOPR_PREFIX = "HOPR Signed Message: ";
+
+const secretKey = Uint8Array.from(utils.arrayify(`0x${process.env.HOPR_DASHBOARD_API_PRIVATE_KEY}`))
+const provider = new Ed25519Provider(secretKey)
+const did = new DID({ provider, resolver: KeyResolver.getResolver() })
+const client = new CeramicClient(CERAMIC_API_URL)
+let tile = null
 
 export default async (req, res) => {
   const { address } = req.query;
@@ -39,10 +54,23 @@ export default async (req, res) => {
     );
 
     if (isAddressOwnerOfNode) {
+      // @TODO: Move from API endpoint as this gets called everytime.
+      if (!tile) {
+        await did.authenticate()
+        client.setDID(did)
+        tile = await TileDocument.create(client, {})
+      }
+
+      const records = await TileDocument.load(client, tile.id)
+      const mutatedRecords = Object.assign({}, records.content, { [hoprAddress]: ethAddress })
+      await tile.update(mutatedRecords)
+
       return res.status(200).json({
         status: "ok",
-        message: `Your signature match and we connected it to our database.`,
+        tile: tile.id.toString(),
+        message: `Your node was recorded into the Ceramic network.`,
       });
+
     } else {
       return res.status(200).json({
         status: "invalid",

--- a/pages/api/sign/verify/[address].js
+++ b/pages/api/sign/verify/[address].js
@@ -29,9 +29,9 @@ export default async (req, res) => {
 
   if (isValidSignature) {
     const checksumedAddress = utils.getAddress(address);
-
     const { hoprSignature, hoprAddress, ethAddress } = message;
     const messageSignedByNode = `${HOPR_PREFIX}${ethAddress}`;
+
     const isAddressOwnerOfNode = await verifySignatureFromPeerId(
       hoprAddress,
       messageSignedByNode,

--- a/pages/api/sign/verify/[address].js
+++ b/pages/api/sign/verify/[address].js
@@ -1,0 +1,60 @@
+import {
+  HOPR_WEB3_SIGNATURE_DOMAIN,
+  HOPR_WEB3_SIGNATURE_FOR_NODE_TYPES,
+  TOKEN_ADDRESS_POLYGON,
+} from "../../../../constants/hopr";
+import { verifySignatureFromPeerId } from "@hoprnet/hopr-utils";
+import { formatEther } from "@ethersproject/units";
+import HOPR_TOKEN_ABI from "../../../../constants/HoprTokenABI";
+import { providers, utils, Wallet, Contract } from "ethers";
+
+// NB: HOPR Node sign messages using the prefix to avoid having
+// the nodes sign any generic data which could be used maliciously
+// (e.g. a transfer request). Thus, we need to prefix the message
+// to get a valid signature.
+// see https://github.com/hoprnet/hoprnet/blob/master/packages/core/src/index.ts#L865-L870
+const HOPR_PREFIX = "HOPR Signed Message: ";
+
+export default async (req, res) => {
+  const { address } = req.query;
+  const { signature, message } = req.body;
+
+  const signerAddress = utils.verifyTypedData(
+    HOPR_WEB3_SIGNATURE_DOMAIN,
+    HOPR_WEB3_SIGNATURE_FOR_NODE_TYPES,
+    message,
+    signature
+  );
+  const isValidSignature = address == signerAddress;
+
+  if (isValidSignature) {
+    const checksumedAddress = utils.getAddress(address);
+
+    const { hoprSignature, hoprAddress, ethAddress } = message;
+    const messageSignedByNode = `${HOPR_PREFIX}${ethAddress}`;
+    const isAddressOwnerOfNode = await verifySignatureFromPeerId(
+      hoprAddress,
+      messageSignedByNode,
+      hoprSignature
+    );
+
+    if (isAddressOwnerOfNode) {
+      return res.status(200).json({
+        status: "ok",
+        message: `Your signature match and we connected it to our database.`,
+      });
+    } else {
+      return res.status(200).json({
+        status: "invalid",
+        address: checksumedAddress,
+        node: hoprAddress,
+        message: `Your signature does not match the address you are submitting. Please try with a new signature.`,
+      });
+    }
+  } else {
+    return res.json({
+      status: "err",
+      message: "Signature is invalid.",
+    });
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,15 +1151,30 @@
     rxjs "^7.0.0"
     uint8arrays "^2.0.5"
 
-"@ceramicnetwork/http-client@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@ceramicnetwork/http-client/-/http-client-1.1.1.tgz#80f21b5d33f4f6c551866ecebae3c8e3a68e63f2"
-  integrity sha512-beiPYQBhP+hpwHzjQGSUMpLHGVo+QqZ83i6F8977qyOy5dMYl5IQqujYV15oRB5fIrPW3ymNLdQyQo88LllhEg==
+"@ceramicnetwork/common@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@ceramicnetwork/common/-/common-1.3.0.tgz#318b6c27df22766c09666a7d7815dc5a5211aba5"
+  integrity sha512-KD96Fp84THtKEA5tVmtjw0i8uw3ewYaGtVYUF/eTn7gs1UGkzi3os3TW3mLZfXKoivoKq/5EioPDlB30HfALag==
   dependencies:
-    "@ceramicnetwork/common" "^1.2.1"
-    "@ceramicnetwork/stream-caip10-link" "^1.1.1"
-    "@ceramicnetwork/stream-tile" "^1.1.1"
-    "@ceramicnetwork/streamid" "^1.1.1"
+    "@ceramicnetwork/streamid" "^1.1.2"
+    "@overnightjs/logger" "^1.2.0"
+    cids "~1.1.6"
+    cross-fetch "^3.1.4"
+    flat "^5.0.2"
+    lodash.clonedeep "^4.5.0"
+    logfmt "^1.3.2"
+    rxjs "^7.0.0"
+    uint8arrays "^2.0.5"
+
+"@ceramicnetwork/http-client@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ceramicnetwork/http-client/-/http-client-1.2.0.tgz#2f087ebc77f6a265b763ff1464f52c1cea6e4ab3"
+  integrity sha512-HLYBwNfoWZODow9jIWp0pANoWn9jJZrVU21xxzELpsauOqMVKnttwSYVMcg7o9ymGs9QXcofDX0gPLrN6cq7/g==
+  dependencies:
+    "@ceramicnetwork/common" "^1.3.0"
+    "@ceramicnetwork/stream-caip10-link" "^1.1.2"
+    "@ceramicnetwork/stream-tile" "^1.2.0"
+    "@ceramicnetwork/streamid" "^1.1.2"
     query-string "7.0.1"
     rxjs "^7.0.0"
 
@@ -1192,13 +1207,23 @@
     "@ceramicnetwork/transport-postmessage" "^0.3.0"
     rpc-utils "^0.3.4"
 
-"@ceramicnetwork/stream-caip10-link@^1.0.0", "@ceramicnetwork/stream-caip10-link@^1.1.1":
+"@ceramicnetwork/stream-caip10-link@^1.0.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@ceramicnetwork/stream-caip10-link/-/stream-caip10-link-1.1.1.tgz#c9b5207cdbe13f8e2776d9b5f5e79bc95a0d0dab"
   integrity sha512-oUN/DtRVUdybgLaIoRlQHz+SrLhgtI8aLwjXsHzuXAupLiZMutuJEE3+hE1GW9hMgG7W/GGvyS3raFrDXf7obQ==
   dependencies:
     "@ceramicnetwork/common" "^1.2.1"
     "@ceramicnetwork/streamid" "^1.1.1"
+    caip "~0.9.2"
+    eip55 "^2.1.0"
+
+"@ceramicnetwork/stream-caip10-link@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@ceramicnetwork/stream-caip10-link/-/stream-caip10-link-1.1.2.tgz#deacefd0314bd1bada51649f92d7dcab69071608"
+  integrity sha512-6ETC38N47zCVWam8w0Gcw4oQ/rsu1mV9W5prEF0xAvWwbqJ03HOruKV5o11QwwePdEPN5a6e3LxIyqKJ/Blc3w==
+  dependencies:
+    "@ceramicnetwork/common" "^1.3.0"
+    "@ceramicnetwork/streamid" "^1.1.2"
     caip "~0.9.2"
     eip55 "^2.1.0"
 
@@ -1213,10 +1238,32 @@
     fast-json-patch "^2.2.1"
     uint8arrays "^2.0.5"
 
+"@ceramicnetwork/stream-tile@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ceramicnetwork/stream-tile/-/stream-tile-1.2.0.tgz#527bff80f9a4b236d5bed828a9f354cc6dbedadf"
+  integrity sha512-d5IooWfWql9duS7cZoamQ2Z0vGJ7KM+mM2Ep9AxUbpBf+oHXexQdy9JOftxWlv37hmYZbjxcmP5rrJrig7cTTQ==
+  dependencies:
+    "@ceramicnetwork/common" "^1.3.0"
+    "@ceramicnetwork/streamid" "^1.1.2"
+    "@stablelib/random" "^1.0.0"
+    fast-json-patch "^2.2.1"
+    uint8arrays "^2.0.5"
+
 "@ceramicnetwork/streamid@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@ceramicnetwork/streamid/-/streamid-1.1.1.tgz#4986880f81049a85f47713cb839a4883d606fd6e"
   integrity sha512-oa4SZtH1/TnUj/XeaL5/Mh7yYZccLpvI6ag4yldmtAoJr1x488mrvKpk/p95pvsCVu+4W355eS1eSzlJjnNRhw==
+  dependencies:
+    cids "~1.1.6"
+    multibase "~4.0.2"
+    typescript-memoize "^1.0.0-alpha.4"
+    uint8arrays "^2.0.5"
+    varint "^6.0.0"
+
+"@ceramicnetwork/streamid@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@ceramicnetwork/streamid/-/streamid-1.1.2.tgz#d1457ce8818cf4876dd46e86738b5b4daddd2457"
+  integrity sha512-b5D44gs6T3MJRYyoJe/IFgnP/k0R/2k8txHZOFisHfYSMSzjMNgryH6Q8bz368x+HdvU5vQvxmqIVz8gvM5qZg==
   dependencies:
     cids "~1.1.6"
     multibase "~4.0.2"
@@ -1907,7 +1954,7 @@
   resolved "https://registry.yarnpkg.com/@stablelib/constant-time/-/constant-time-1.0.1.tgz#bde361465e1cf7b9753061b77e376b0ca4c77e35"
   integrity sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==
 
-"@stablelib/ed25519@^1.0.2":
+"@stablelib/ed25519@^1.0.1", "@stablelib/ed25519@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@stablelib/ed25519/-/ed25519-1.0.2.tgz#937a88a2f73a71d9bdc3ea276efe8954776ae0f4"
   integrity sha512-FtnvUwvKbp6l1dNcg4CswMAVFVu/nzLK3oC7/PRtjYyHbWsIkD8j+5cjXHmwcCpdCpRCaTGACkEhhMQ1RcdSOQ==
@@ -3692,6 +3739,22 @@ des.js@^1.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
+did-jwt@^5.0.1:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-5.7.0.tgz#7c5284daece5c86388db90e1274d0df63bb20f52"
+  integrity sha512-etWD68ZugZ+mf9PoA+unFc1A9IPrCpD8CXeOu7cCLOtXum30TO6OU73a+AoDPie1R4knO1yGLv/3dPZ68CufFw==
+  dependencies:
+    "@stablelib/ed25519" "^1.0.2"
+    "@stablelib/random" "^1.0.1"
+    "@stablelib/sha256" "^1.0.1"
+    "@stablelib/x25519" "^1.0.1"
+    "@stablelib/xchacha20poly1305" "^1.0.1"
+    canonicalize "^1.0.5"
+    did-resolver "^3.1.0"
+    elliptic "^6.5.4"
+    js-sha3 "^0.8.0"
+    uint8arrays "^3.0.0"
+
 did-jwt@^5.6.1:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-5.6.3.tgz#b04213cd094f85f390cfa19591f92cc88e2563aa"
@@ -4290,7 +4353,7 @@ fast-json-patch@^2.2.1:
   dependencies:
     fast-deep-equal "^2.0.1"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -5467,6 +5530,27 @@ keccak@^1.3.0:
     inherits "^2.0.3"
     nan "^2.2.1"
     safe-buffer "^5.1.0"
+
+key-did-provider-ed25519@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/key-did-provider-ed25519/-/key-did-provider-ed25519-1.1.0.tgz#4c8bb9581352457faa0593d46e77dad9aa16f3ba"
+  integrity sha512-kSxpmqYvTCXKTiApgVep3kTqEpUyRMQktaS3R1TD1Y1GbjFLG1RKShQ5qZRK7Z7Gar15Ym3tk3kMjYg76Xe6zQ==
+  dependencies:
+    "@stablelib/ed25519" "^1.0.1"
+    did-jwt "^5.0.1"
+    fast-json-stable-stringify "^2.1.0"
+    rpc-utils "^0.3.4"
+    uint8arrays "^2.1.5"
+
+key-did-resolver@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/key-did-resolver/-/key-did-resolver-1.4.0.tgz#a3b58f6d1956070813aba4394fc66ec46befb789"
+  integrity sha512-Qkp8o7Vx5VRlSEyOV5Hw/qVAyZyxLJNua2x2Ojw9QBn5JEYKIqSq5ig+MAj2gnsIYQGKu6Gl1x/FvD1ptSv96w==
+  dependencies:
+    "@stablelib/ed25519" "^1.0.2"
+    multibase "~4.0.2"
+    uint8arrays "^2.0.5"
+    varint "^6.0.0"
 
 keypair@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
- Fixes #59 
- Verification on node requires `hoprAddress` and output of `sign $ethereumAddress`, assuming the verification is signed with the Ethereum address used at the process.
- Query currently available on `/api/sign/get/all`